### PR TITLE
fix: authors field not serialized in Velocity json

### DIFF
--- a/plugin/src/main/kotlin/xyz/jpenilla/resourcefactory/velocity/VelocityPluginJson.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/resourcefactory/velocity/VelocityPluginJson.kt
@@ -122,6 +122,7 @@ class VelocityPluginJson constructor(
         val version = json.version.orNull
         val description = json.description.orNull
         val url = json.url.orNull
+        val authors = json.authors.nullIfEmpty()
         val dependencies = json.dependencies.nullIfEmpty()?.onEach { it::id.validate() }
         val main = json.main.get()
     }


### PR DESCRIPTION
PR adds missing authors field to serialized json in VelocityPluginJson